### PR TITLE
Update version to 0.2.0-beta in manifest.json

### DIFF
--- a/custom_components/elevenlabs_custom_tts/manifest.json
+++ b/custom_components/elevenlabs_custom_tts/manifest.json
@@ -10,5 +10,5 @@
   "issue_tracker": "https://github.com/loryanstrant/HA-ElevenLabs-Custom-TTS/issues",
   "loggers": ["elevenlabs"],
   "requirements": ["elevenlabs==2.3.0"],
-  "version": "0.1.0-alpha"
+  "version": "0.2.0-beta"
 }


### PR DESCRIPTION
This pull request updates the version number of the `elevenlabs_custom_tts` component to reflect a new beta release.

- Versioning:
  * Updated the `version` field in `manifest.json` from `0.1.0-alpha` to `0.2.0-beta`.