### PR TITLE
Documentation add screenshots

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ data:
     voice_profile: "Morgan Freeman Style"  # Use your saved profile
 ```
 
-<img width="1771" height="1233" alt="image" src="https://github.com/user-attachments/assets/624e6595-e8d4-4c2e-bf18-af6a38d14bcb" />
+<img width="1771" height="1233" alt="Home Assistant automation configuration showing voice profile usage" src="https://github.com/user-attachments/assets/624e6595-e8d4-4c2e-bf18-af6a38d14bcb" />
 
 
 You can also combine voice profiles with custom options (custom options override profile settings):

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ After installation, you can create and manage voice profiles through the Home As
 3. Update any settings you want to change
 4. Click **Submit** to save changes
 
-<img width="1250" height="741" alt="image" src="https://github.com/user-attachments/assets/ba26b3b7-a753-445e-a491-1525d52e7b79" />
+<img width="1250" height="741" alt="Modify Voice Profile interface showing editable settings" src="https://github.com/user-attachments/assets/ba26b3b7-a753-445e-a491-1525d52e7b79" />
 
 
 #### Deleting a Profile

--- a/README.md
+++ b/README.md
@@ -93,7 +93,8 @@ After installation, you can create and manage voice profiles through the Home As
    - **Enable Speaker Boost**: Enhance speaker clarity (default: true)
 3. Click **Submit** to save the profile
 
-<img width="1400" height="1230" alt="image" src="https://github.com/user-attachments/assets/92c0acd5-9336-4a1d-8181-d9eb1154c01d" />
+<img width="1282" height="1184" alt="image" src="https://github.com/user-attachments/assets/6c9d8f81-7062-4abb-970e-7a850013cb8a" />
+
 
 
 #### Modifying an Existing Profile
@@ -103,8 +104,8 @@ After installation, you can create and manage voice profiles through the Home As
 3. Update any settings you want to change
 4. Click **Submit** to save changes
 
-<!-- TODO: Add screenshot of modify voice profile interface -->
-<!-- ![Modify Voice Profile](docs/images/modify-voice-profile.png) -->
+<img width="1250" height="741" alt="image" src="https://github.com/user-attachments/assets/ba26b3b7-a753-445e-a491-1525d52e7b79" />
+
 
 #### Deleting a Profile
 
@@ -112,8 +113,6 @@ After installation, you can create and manage voice profiles through the Home As
 2. Choose the profile to delete from the dropdown
 3. Confirm the deletion
 
-<!-- TODO: Add screenshot of delete voice profile interface -->
-<!-- ![Delete Voice Profile](docs/images/delete-voice-profile.png) -->
 
 ### Using Voice Profiles
 
@@ -128,6 +127,9 @@ data:
   options:
     voice_profile: "Morgan Freeman Style"  # Use your saved profile
 ```
+
+<img width="1771" height="1233" alt="image" src="https://github.com/user-attachments/assets/624e6595-e8d4-4c2e-bf18-af6a38d14bcb" />
+
 
 You can also combine voice profiles with custom options (custom options override profile settings):
 

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ After installation, you can create and manage voice profiles through the Home As
 3. Click **Configure** (or the gear icon)
 4. You'll see the Voice Profile Management interface
 
-<img width="1555" height="879" alt="image" src="https://github.com/user-attachments/assets/316fce70-0322-41c3-98e3-4badb423e7de" />
+<img width="1555" height="879" alt="Voice Profile Management interface in Home Assistant" src="https://github.com/user-attachments/assets/316fce70-0322-41c3-98e3-4badb423e7de" />
 
 
 ### Managing Voice Profiles

--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ After installation, you can create and manage voice profiles through the Home As
 3. Click **Configure** (or the gear icon)
 4. You'll see the Voice Profile Management interface
 
+<img width="1555" height="879" alt="image" src="https://github.com/user-attachments/assets/316fce70-0322-41c3-98e3-4badb423e7de" />
 
 
 ### Managing Voice Profiles
@@ -92,6 +93,7 @@ After installation, you can create and manage voice profiles through the Home As
    - **Enable Speaker Boost**: Enhance speaker clarity (default: true)
 3. Click **Submit** to save the profile
 
+<img width="1400" height="1230" alt="image" src="https://github.com/user-attachments/assets/92c0acd5-9336-4a1d-8181-d9eb1154c01d" />
 
 
 #### Modifying an Existing Profile

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ After installation, you can create and manage voice profiles through the Home As
    - **Enable Speaker Boost**: Enhance speaker clarity (default: true)
 3. Click **Submit** to save the profile
 
-<img width="1282" height="1184" alt="image" src="https://github.com/user-attachments/assets/6c9d8f81-7062-4abb-970e-7a850013cb8a" />
+<img width="1282" height="1184" alt="Create New Voice Profile dialog showing configuration options" src="https://github.com/user-attachments/assets/6c9d8f81-7062-4abb-970e-7a850013cb8a" />
 
 
 


### PR DESCRIPTION
This pull request updates the `README.md` to improve the documentation for managing voice profiles by adding relevant screenshots throughout the guide. These visual aids make it easier for users to understand and follow the instructions.

Documentation improvements:

* Added a screenshot of the Voice Profile Management interface after installation to visually guide users through the initial setup.
* Included a screenshot for the "Create a New Profile" section to illustrate the profile creation process.
* Added a screenshot for modifying an existing voice profile, replacing the previous TODO and placeholder image.
* Inserted a screenshot in the section demonstrating how to use a voice profile in the configuration example.