### PR TITLE
Bump version to 0.6.2 in manifest.json

### DIFF
--- a/custom_components/elevenlabs_custom_tts/manifest.json
+++ b/custom_components/elevenlabs_custom_tts/manifest.json
@@ -10,5 +10,5 @@
   "issue_tracker": "https://github.com/loryanstrant/HA-ElevenLabs-Custom-TTS/issues",
   "loggers": ["elevenlabs"],
   "requirements": ["elevenlabs==2.3.0"],
-  "version": "0.6.0"
+  "version": "0.6.2"
 }


### PR DESCRIPTION
This pull request updates the version number of the `elevenlabs_custom_tts` integration in its manifest file.

* Bumped the `version` field in `custom_components/elevenlabs_custom_tts/manifest.json` from `0.6.0` to `0.6.2`.
(whoops)