### PR TITLE
docs: add troubleshooting notes for free-tier 402 / library-voice errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -372,11 +372,22 @@ When using Home Assistant's native TTS services, you can pass these options:
 - Ensure you're using the correct `voice_profile` name (case-sensitive)
 - Check that the profile exists in Settings → Integrations → ElevenLabs Custom TTS → Configure
 - Verify the voice profile contains valid ElevenLabs voice IDs
+- If a `tts.speak` call omits `voice_profile`, the integration falls back to the hardcoded default voice ID (`21m00Tcm4TlvDq8ikWAM`). On free-tier ElevenLabs accounts this default returns 402 — always specify `voice_profile` and point it at a `category: generated` voice. See **API Errors** above.
 
 ### API Errors
-- Verify your ElevenLabs API key is correct and has sufficient quota
-- Check Home Assistant logs for detailed error messages
-- Ensure your internet connection is stable
+
+- **`402 paid_plan_required` / "Free users cannot use library voices via the API"** — ElevenLabs restricts free-tier API access to voices in the `generated` category (voices you created yourself with **Voice Design**). Voices in `premade`, `professional`, or library-cloned categories return HTTP 402 **even after they've been added to your VoiceLab.** This includes the integration's hardcoded default voice (`21m00Tcm4TlvDq8ikWAM`, "Rachel"), so any `tts.speak` call made without `voice_profile` set will 402 on free-tier accounts.
+
+  | Voice category | Source | Free-tier API |
+  |---|---|---|
+  | `premade` | ElevenLabs default sample voices (Rachel, Bella, Adam, …) | ❌ |
+  | `professional` | Curated paid-licence voices | ❌ |
+  | `cloned` from library | Added to your VoiceLab from the public library | ❌ |
+  | `generated` | Voices you created yourself with **Voice Design** | ✅ |
+
+  To check which voices on your account are usable, call `elevenlabs_custom_tts.get_voices` (Developer Tools → Actions, with "Return response" ticked) and look for entries with `"category": "generated"`. Use one of those voice IDs in your profile.
+
+- **Other API errors** — Verify your ElevenLabs API key is correct and has sufficient quota. Check Home Assistant logs for detailed error messages. Ensure your internet connection is stable.
 
 ### Integration Not Loading
 - Restart Home Assistant after installation


### PR DESCRIPTION
Hi! 👋 First — thanks for this integration. The profile system and the extra parameters over the official ElevenLabs one are exactly what I was after, and switching my bedtime brief over to it was super easy.

The one thing that did catch me out for a while was the interaction between the ElevenLabs free-tier API rules and the integration's default voice fallback. Symptom: every tts.speak call returns successfully in the logbook, the entity's last-updated timestamp ticks forward, but no audio ever plays. Took me a fair bit of digging through paid_plan_required errors to realise:

On free tier, only category: generated voices are callable via the API. premade, professional, and library-cloned voices all 402, even after they've been added to VoiceLab.
The integration's hardcoded fallback (21m00Tcm4TlvDq8ikWAM, Rachel) is itself a premade voice — so any tts.speak call missing voice_profile will 402 on free-tier accounts before it even reaches a user-configured profile.

Once I knew that, the fix was trivial — design a voice in ElevenLabs (category: generated), put it in a profile, reference the profile by name. But I'd love to save the next person an evening of confused log-spelunking, so this PR just adds two small troubleshooting entries:

Replaces the API Errors subsection with one that explains the 402 / library-voice rule and includes a quick compatibility table.
Adds a bullet to Voice Profiles Not Working noting that omitting voice_profile falls back to the premade default (which 402s on free tier).
Both are doc-only and in the existing Troubleshooting section, so no behaviour changes and nothing existing is moved around.

Thanks again for maintaining this! 